### PR TITLE
Updated ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-This repository stores working documents related to the development of MAEC, such as mind maps.
+# MAEC Working Documents
 
+A repository for working documents related to the development of MAEC, such as mind maps.
+
+##About MAEC
+
+Malware Attribute Enumeration and Characterization (MAEC™) is a standardized language for sharing structured information about malware based upon attributes such as behaviors, artifacts, and attack patterns.
+
+The goal of the MAEC (pronounced "mike") effort is to provide a basis for transforming malware research and response. MAEC aims to eliminate the ambiguity and inaccuracy that currently exists in malware descriptions and to reduce reliance on signatures. In this way, MAEC seeks to improve human-to-human, human-to-tool, tool-to-tool, and tool-to-human communication about malware; reduce potential duplication of malware analysis efforts by researchers; and allow for the faster development of countermeasures by enabling the ability to leverage responses to previously observed malware instances. The MAEC Language enables correlation, integration, and automation.
+
+Please visit the [MAEC website](http://maecproject.github.io/) for more information about the MAEC Language.
+
+##Getting Help
+
+Join the public [MAEC Community Email Discussion List](https://maec.mitre.org/community/discussionlist.html).
+
+Email the MAEC Developers at maec@mitre.org.


### PR DESCRIPTION
Added background info about MAEC, to make this page consistent with the other ReadMe pages in this format. Spelled-out MAEC. Added links back to the main MAEC website, and to the MAEC Discussion List and maec email address.
